### PR TITLE
feat : HTTP API Gateway 방 진입 시 message 조회 Lambda 함수 구현

### DIFF
--- a/backend/http/room/message/get/handler.spec.ts
+++ b/backend/http/room/message/get/handler.spec.ts
@@ -1,0 +1,27 @@
+import {handler} from "@/http/room/message/get/handler";
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+
+describe("getMessages Lambda handler", () => {
+    it("should return 200 with messages for a valid room ID", async () => {
+        const mockEvent: APIGatewayProxyEvent = {
+            pathParameters: { roomId: "b408c472-58fb-4f80-9835-94ae0642deb5" },
+        } as unknown as APIGatewayProxyEvent;
+
+        const response = await handler(mockEvent, {} as any, () => {}) as APIGatewayProxyResult;
+
+        // console.log("Status Code:", response.statusCode);
+        // console.log("Parsed Body:", JSON.parse(response.body));
+
+        const parsedResponse = JSON.parse(response.body);
+        expect(parsedResponse).toEqual({
+            messages: expect.arrayContaining([
+                expect.objectContaining({
+                    messageId: expect.any(String),
+                    content: expect.any(String),
+                    createdAt: expect.any(String),
+                    senderId: expect.any(String),
+                }),
+            ]),
+            });
+        });
+    });

--- a/backend/http/room/message/get/handler.ts
+++ b/backend/http/room/message/get/handler.ts
@@ -1,0 +1,47 @@
+// lambda function to get messages in a room
+import { APIGatewayProxyEvent, APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda";
+import { getMessages } from "@/http/room/message/get/service";
+import { AppError } from "@/common/errors/AppError";
+
+export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const roomId = event.pathParameters?.roomId;
+
+    if (!roomId) {
+        return {
+            statusCode: 400,
+            body: JSON.stringify({
+                message: "Room ID is required"
+            })
+        };
+    }
+
+    try {
+        const response = await getMessages(roomId);
+
+        return {
+            statusCode: 200,
+            body: JSON.stringify(response)
+        };
+
+    } catch (error) {
+        if (error instanceof AppError) {
+            // console.error("AppError:", error);
+            
+            return {
+                statusCode: error.statusCode,
+                body: JSON.stringify({
+                    message: error.message
+                })
+            };
+        }
+
+        // console.error("Unexpected error:", error);
+
+        return {
+            statusCode: 500,
+            body: JSON.stringify({
+                message: "Internal server error"
+            })
+        };
+    }
+};

--- a/backend/http/room/message/get/service.ts
+++ b/backend/http/room/message/get/service.ts
@@ -13,7 +13,7 @@ export const getMessages = async (roomId: string): Promise<GetRoomMessagesRespon
         messages: messages.map(message => ({
             messageId: message.messageId,
             content: message.content,
-            createdAt: message.createdAt,
+            timestamp: message.timestamp,
             senderId: message.senderId,
         })),
     };

--- a/backend/http/room/message/get/service.ts
+++ b/backend/http/room/message/get/service.ts
@@ -1,0 +1,22 @@
+// lambda function to get messages in a room
+import { GetRoomMessagesResponse } from "@/http/room/model";
+
+import { fetchMessagesFromDynamoDB } from "@/http/room/message/get/usecases/fetchMessagesFromDynamoDB";
+
+export const getMessages = async (roomId: string): Promise<GetRoomMessagesResponse> => {
+
+    // 1. Fetch messages from DynamoDB
+    const messages = await fetchMessagesFromDynamoDB(roomId);
+
+    // 2. Return the response
+    const responseBody: GetRoomMessagesResponse = {
+        messages: messages.map(message => ({
+            messageId: message.messageId,
+            content: message.content,
+            createdAt: message.createdAt,
+            senderId: message.senderId,
+        })),
+    };
+
+    return responseBody;
+};

--- a/backend/http/room/message/get/usecases/fetchMessagesFromDynamoDB.ts
+++ b/backend/http/room/message/get/usecases/fetchMessagesFromDynamoDB.ts
@@ -1,0 +1,32 @@
+import { Message } from "@/http/room/model";
+
+import { docClient } from "@/common/constants/dynamo";
+import { TABLE_NAME_MESSAGE } from "@/common/constants/table";
+import { DatabaseError } from "@/common/errors/DatabaseError";
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+export const fetchMessagesFromDynamoDB = async (
+  roomId: string
+): Promise<Message[]> => {
+  const params = {
+    TableName: TABLE_NAME_MESSAGE,
+    KeyConditionExpression: "roomId = :roomId",
+    ExpressionAttributeValues: {
+      ":roomId": roomId,
+    },
+    ScanIndexForward: true, // true = ASC, false = DESC
+  };
+
+  try {
+    const response = await docClient.send(new QueryCommand(params));
+
+    return response.Items as Message[] || [];
+
+  } catch (error: unknown) {
+    const message =
+      error instanceof Error ? error.message : JSON.stringify(error);
+    throw new DatabaseError(
+      "Failed [DynamoDB] in [fetchMessagesFromDynamoDB] use case: " + message
+    );
+  }
+};

--- a/backend/http/room/model.ts
+++ b/backend/http/room/model.ts
@@ -49,7 +49,7 @@ export const updateRoomResponseSchema = z.object({
 const messageSchema = z.object({
     messageId: z.string(),
     content: z.string(),
-    createdAt: z.string(),
+    timestamp: z.string(),
     senderId: z.string(),
 });
 

--- a/backend/http/room/model.ts
+++ b/backend/http/room/model.ts
@@ -44,7 +44,18 @@ export const updateRoomResponseSchema = z.object({
     title: z.string(),
 });
 
+/** ======================= Get Room Messages HTTP API ======================= **/
 
+const messageSchema = z.object({
+    messageId: z.string(),
+    content: z.string(),
+    createdAt: z.string(),
+    senderId: z.string(),
+});
+
+export const getRoomMessagesResponseSchema = z.object({
+    messages: z.array(messageSchema),
+});
 
 /** ======================= Types ======================= **/
 
@@ -55,3 +66,6 @@ export type CreateRoomResponse = z.infer<typeof createRoomResponseSchema>;
 export type DeleteRoomRequest = z.infer<typeof deleteRoomRequestSchema>;
 export type UpdateRoomRequest = z.infer<typeof updateRoomRequestSchema>;
 export type UpdateRoomResponse = z.infer<typeof updateRoomResponseSchema>;
+
+export type Message = z.infer<typeof messageSchema>;
+export type GetRoomMessagesResponse = z.infer<typeof getRoomMessagesResponseSchema>;

--- a/backend/websocket/sendMessage/handler.ts
+++ b/backend/websocket/sendMessage/handler.ts
@@ -7,6 +7,7 @@ import {
   APIGatewayProxyResultV2,
   APIGatewayProxyWebsocketEventV2,
 } from "aws-lambda";
+import { v4 as uuidv4 } from 'uuid';
 
 import { docClient } from "@/common/constants/dynamo";
 import {
@@ -40,7 +41,8 @@ export const handler = async function (
       TableName: TABLE_NAME_MESSAGE,
       Item: {
         roomId,
-        message: message,
+        messageId: uuidv4(),
+        content: message,
         senderId: event.requestContext.connectionId,
         timestamp: new Date().toISOString(),
       },


### PR DESCRIPTION
## Related issue 🛠

[//]: # "해당하는 이슈 번호 달아주기"

- closes #8 

## Work Description ✏️

[//]: # "작업 내용 간단 소개"

- HTTP API Gateway 방 진입 시 message 조회 Lambda 함수 구현
- ws api의 sendMessage -> messages db field 수정

## Uncompleted Tasks 😅

[//]: # "없다면 N/A"

N/A

## To Reviewers 📢

[//]: # "reviewer가 알면 좋은 내용들"